### PR TITLE
escape quotes and improve consistency in install.sh

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -23,7 +23,7 @@ DOWNLOAD_TAG_INSTALL_SCRIPT=${DOWNLOAD_TAG_INSTALL_SCRIPT:-true}
 # usage [script-name]
 #
 usage() (
-  this=$1
+  this="$1"
   cat <<EOF
 $this: download go binaries for ${OWNER}/${REPO}
 
@@ -75,7 +75,7 @@ init_colors() {
   if test -t 1 && is_command tput; then
       # see if it supports colors
       ncolors=$(tput colors)
-      if test -n "$ncolors" && test $ncolors -ge 8; then
+      if test -n "$ncolors" && test "$ncolors" -ge 8; then
         RED='\033[0;31m'
         BLUE='\033[0;34m'
         PURPLE='\033[0;35m'
@@ -88,7 +88,7 @@ init_colors() {
 init_colors
 
 log_tag() (
-  case $1 in
+  case "$1" in
     0) echo "${RED}${BOLD}[error]${RESET}" ;;
     1) echo "${RED}[warn]${RESET}" ;;
     2) echo "[info]${RESET}" ;;
@@ -103,39 +103,39 @@ log_trace_priority=4
 log_trace() (
   priority=$log_trace_priority
   log_priority "$priority" || return 0
-  echo_stderr "$(log_tag $priority)" "${@}" "${RESET}"
+  echo_stderr "$(log_tag $priority)" "${@}" "$RESET"
 )
 
 log_debug_priority=3
 log_debug() (
   priority=$log_debug_priority
   log_priority "$priority" || return 0
-  echo_stderr "$(log_tag $priority)" "${@}" "${RESET}"
+  echo_stderr "$(log_tag $priority)" "${@}" "$RESET"
 )
 
 log_info_priority=2
 log_info() (
   priority=$log_info_priority
   log_priority "$priority" || return 0
-  echo_stderr "$(log_tag $priority)" "${@}" "${RESET}"
+  echo_stderr "$(log_tag $priority)" "${@}" "$RESET"
 )
 
 log_warn_priority=1
 log_warn() (
   priority=$log_warn_priority
   log_priority "$priority" || return 0
-  echo_stderr "$(log_tag $priority)" "${@}" "${RESET}"
+  echo_stderr "$(log_tag $priority)" "${@}" "$RESET"
 )
 
 log_err_priority=0
 log_err() (
   priority=$log_err_priority
   log_priority "$priority" || return 0
-  echo_stderr "$(log_tag $priority)" "${@}" "${RESET}"
+  echo_stderr "$(log_tag $priority)" "${@}" "$RESET"
 )
 
 uname_os_check() (
-  os=$1
+  os="$1"
   case "$os" in
     darwin) return 0 ;;
     dragonfly) return 0 ;;
@@ -154,7 +154,7 @@ uname_os_check() (
 )
 
 uname_arch_check() (
-  arch=$1
+  arch="$1"
   case "$arch" in
     386) return 0 ;;
     amd64) return 0 ;;
@@ -176,15 +176,15 @@ uname_arch_check() (
 )
 
 unpack() (
-  archive=$1
+  archive="$1"
 
   log_trace "unpack(archive=${archive})"
 
-  case "${archive}" in
-    *.tar.gz | *.tgz) tar --no-same-owner -xzf "${archive}" ;;
-    *.tar) tar --no-same-owner -xf "${archive}" ;;
-    *.zip) unzip -q "${archive}" ;;
-    *.dmg) extract_from_dmg "${archive}" ;;
+  case "$archive" in
+    *.tar.gz | *.tgz) tar --no-same-owner -xzf "$archive" ;;
+    *.tar) tar --no-same-owner -xf "$archive" ;;
+    *.zip) unzip -q "$archive" ;;
+    *.dmg) extract_from_dmg "$archive" ;;
     *)
       log_err "unpack unknown archive format for ${archive}"
       return 1
@@ -193,18 +193,18 @@ unpack() (
 )
 
 extract_from_dmg() (
-  dmg_file=$1
+  dmg_file="$1"
 
   mount_point="/Volumes/tmp-dmg"
-  hdiutil attach -quiet -nobrowse -mountpoint "${mount_point}" "${dmg_file}"
+  hdiutil attach -quiet -nobrowse -mountpoint "$mount_point" "$dmg_file"
   cp -fR "${mount_point}/." ./
-  hdiutil detach -quiet -force "${mount_point}"
+  hdiutil detach -quiet -force "$mount_point"
 )
 
 http_download_curl() (
-  local_file=$1
-  source_url=$2
-  header=$3
+  local_file="$1"
+  source_url="$2"
+  header="$3"
 
   log_trace "http_download_curl(local_file=$local_file, source_url=$source_url, header=$header)"
 
@@ -222,9 +222,9 @@ http_download_curl() (
 )
 
 http_download_wget() (
-  local_file=$1
-  source_url=$2
-  header=$3
+  local_file="$1"
+  source_url="$2"
+  header="$3"
 
   log_trace "http_download_wget(local_file=$local_file, source_url=$source_url, header=$header)"
 
@@ -250,9 +250,9 @@ http_download() (
 
 http_copy() (
   tmp=$(mktemp)
-  http_download "${tmp}" "$1" "$2" || return 1
+  http_download "$tmp" "$1" "$2" || return 1
   body=$(cat "$tmp")
-  rm -f "${tmp}"
+  rm -f "$tmp"
   echo "$body"
 )
 
@@ -277,14 +277,14 @@ hash_sha256() (
 )
 
 hash_sha256_verify() (
-  TARGET=$1
-  checksums=$2
+  TARGET="$1"
+  checksums="$2"
   if [ -z "$checksums" ]; then
     log_err "hash_sha256_verify checksum file not specified in arg2"
     return 1
   fi
   BASENAME=${TARGET##*/}
-  want=$(grep "${BASENAME}" "${checksums}" 2>/dev/null | tr '\t' ' ' | cut -d ' ' -f 1)
+  want=$(grep "$BASENAME" "$checksums" 2>/dev/null | tr '\t' ' ' | cut -d ' ' -f 1)
   if [ -z "$want" ]; then
     log_err "hash_sha256_verify unable to find checksum for '${TARGET}' in '${checksums}'"
     return 1
@@ -306,7 +306,7 @@ hash_sha256_verify() (
 #
 asset_file_exists() (
   path="$1"
-  if [ ! -f "${path}" ]; then
+  if [ ! -f "$path" ]; then
       return 1
   fi
 )
@@ -317,9 +317,9 @@ asset_file_exists() (
 # outputs release json string
 #
 github_release_json() (
-  owner=$1
-  repo=$2
-  version=$3
+  owner="$1"
+  repo="$2"
+  version="$3"
   test -z "$version" && version="latest"
   giturl="https://github.com/${owner}/${repo}/releases/${version}"
   json=$(http_copy "$giturl" "Accept:application/json")
@@ -327,7 +327,7 @@ github_release_json() (
   log_trace "github_release_json(owner=${owner}, repo=${repo}, version=${version}) returned '${json}'"
 
   test -z "$json" && return 1
-  echo "${json}"
+  echo "$json"
 )
 
 # extract_value [key-value-pair]
@@ -349,7 +349,7 @@ EOF
 extract_json_value() (
   json="$1"
   key="$2"
-  key_value=$(echo "${json}" | grep  -o "\"$key\":[^,]*[,}]" | tr -d '",}')
+  key_value=$(echo "$json" | grep  -o "\"$key\":[^,]*[,}]" | tr -d '",}')
 
   extract_value "$key_value"
 )
@@ -360,7 +360,7 @@ extract_json_value() (
 #
 github_release_tag() (
   json="$1"
-  tag=$(extract_json_value "${json}" "tag_name")
+  tag=$(extract_json_value "$json" "tag_name")
   test -z "$tag" && return 1
   echo "$tag"
 )
@@ -381,12 +381,12 @@ download_github_release_checksums() (
   checksum_url=${download_url}/${checksum_filename}
   output_path="${output_dir}/${checksum_filename}"
 
-  http_download "${output_path}" "${checksum_url}" ""
-  asset_file_exists "${output_path}"
+  http_download "$output_path" "$checksum_url" ""
+  asset_file_exists "$output_path"
 
   log_trace "download_github_release_checksums() returned '${output_path}'"
 
-  echo "${output_path}"
+  echo "$output_path"
 )
 
 # search_for_asset [checksums-file-path] [name] [os] [arch] [format]
@@ -403,11 +403,11 @@ search_for_asset() (
   log_trace "search_for_asset(checksum-path=${checksum_path}, name=${name}, os=${os}, arch=${arch}, format=${format})"
 
   asset_glob="${name}_.*_${os}_${arch}.${format}"
-  output_path=$(grep -o "${asset_glob}" "${checksum_path}" || true)
+  output_path=$(grep -o "$asset_glob" "$checksum_path" || true)
 
   log_trace "search_for_asset() returned '${output_path}'"
 
-  echo "${output_path}"
+  echo "$output_path"
 )
 
 # uname_os
@@ -435,7 +435,7 @@ uname_os() (
 #
 uname_arch() (
   arch=$(uname -m)
-  case $arch in
+  case "$arch" in
     x86_64) arch="amd64" ;;
     x86) arch="386" ;;
     i686) arch="386" ;;
@@ -446,11 +446,11 @@ uname_arch() (
     armv7*) arch="armv7" ;;
   esac
 
-  uname_arch_check "${arch}"
+  uname_arch_check "$arch"
 
   log_trace "uname_arch() returned '${arch}'"
 
-  echo "${arch}"
+  echo "$arch"
 )
 
 # get_release_tag [owner] [repo] [tag]
@@ -464,15 +464,15 @@ get_release_tag() (
 
   log_trace "get_release_tag(owner=${owner}, repo=${repo}, tag=${tag})"
 
-  json=$(github_release_json "${owner}" "${repo}" "${tag}")
-  real_tag=$(github_release_tag "${json}")
-  if test -z "${real_tag}"; then
+  json=$(github_release_json "$owner" "$repo" "$tag")
+  real_tag=$(github_release_tag "$json")
+  if test -z "$real_tag"; then
     return 1
   fi
 
   log_trace "get_release_tag() returned '${real_tag}'"
 
-  echo "${real_tag}"
+  echo "$real_tag"
 )
 
 # tag_to_version [tag]
@@ -496,15 +496,15 @@ get_binary_name() (
   os="$1"
   arch="$2"
   binary="$3"
-  original_binary="${binary}"
+  original_binary="$binary"
 
-  case "${os}" in
+  case "$os" in
     windows) binary="${binary}.exe" ;;
   esac
 
   log_trace "get_binary_name(os=${os}, arch=${arch}, binary=${original_binary}) returned '${binary}'"
 
-  echo "${binary}"
+  echo "$binary"
 )
 
 
@@ -516,15 +516,15 @@ get_format_name() (
   os="$1"
   arch="$2"
   format="$3"
-  original_format="${format}"
+  original_format="$format"
 
-  case ${os} in
+  case "$os" in
     windows) format=zip ;;
   esac
 
   log_trace "get_format_name(os=${os}, arch=${arch}, format=${original_format}) returned '${format}'"
 
-  echo "${format}"
+  echo "$format"
 )
 
 # download_and_install_asset [release-url-prefix] [download-path] [install-path] [name] [os] [arch] [version] [format] [binary]
@@ -534,7 +534,7 @@ get_format_name() (
 download_and_install_asset() (
   download_url="$1"
   download_path="$2"
-  install_path=$3
+  install_path="$3"
   name="$4"
   os="$5"
   arch="$6"
@@ -542,15 +542,15 @@ download_and_install_asset() (
   format="$8"
   binary="$9"
 
-  asset_filepath=$(download_asset "${download_url}" "${download_path}" "${name}" "${os}" "${arch}" "${version}" "${format}")
+  asset_filepath=$(download_asset "$download_url" "$download_path" "$name" "$os" "$arch" "$version" "$format")
 
   # don't continue if we couldn't download an asset
-  if [ -z "${asset_filepath}" ]; then
+  if [ -z "$asset_filepath" ]; then
       log_err "could not find release asset for os='${os}' arch='${arch}' format='${format}' "
       return 1
   fi
 
-  install_asset "${asset_filepath}" "${install_path}" "${binary}"
+  install_asset "$asset_filepath" "$install_path" "$binary"
 )
 
 # download_asset [release-url-prefix] [download-path] [name] [os] [arch] [version] [format] [binary]
@@ -568,26 +568,26 @@ download_asset() (
 
   log_trace "download_asset(url=${download_url}, destination=${destination}, name=${name}, os=${os}, arch=${arch}, version=${version}, format=${format})"
 
-  checksums_filepath=$(download_github_release_checksums "${download_url}" "${name}" "${version}" "${destination}")
+  checksums_filepath=$(download_github_release_checksums "$download_url" "$name" "$version" "$destination")
 
   log_trace "checksums content:\n$(cat ${checksums_filepath})"
 
-  asset_filename=$(search_for_asset "${checksums_filepath}" "${name}" "${os}" "${arch}" "${format}")
+  asset_filename=$(search_for_asset "$checksums_filepath" "$name" "$os" "$arch" "$format")
 
   # don't continue if we couldn't find a matching asset from the checksums file
-  if [ -z "${asset_filename}" ]; then
+  if [ -z "$asset_filename" ]; then
       return 1
   fi
 
   asset_url="${download_url}/${asset_filename}"
   asset_filepath="${destination}/${asset_filename}"
-  http_download "${asset_filepath}" "${asset_url}" ""
+  http_download "$asset_filepath" "$asset_url" ""
 
-  hash_sha256_verify "${asset_filepath}" "${checksums_filepath}"
+  hash_sha256_verify "$asset_filepath" "$checksums_filepath"
 
   log_trace "download_asset_by_checksums_file() returned '${asset_filepath}'"
 
-  echo "${asset_filepath}"
+  echo "$asset_filepath"
 )
 
 # install_asset [asset-path] [destination-path] [binary]
@@ -600,17 +600,17 @@ install_asset() (
   log_trace "install_asset(asset=${asset_filepath}, destination=${destination}, binary=${binary})"
 
   # don't continue if we don't have anything to install
-  if [ -z "${asset_filepath}" ]; then
+  if [ -z "$asset_filepath" ]; then
       return
   fi
 
-  archive_dir=$(dirname "${asset_filepath}")
+  archive_dir=$(dirname "$asset_filepath")
 
   # unarchive the downloaded archive to the temp dir
-  (cd "${archive_dir}" && unpack "${asset_filepath}")
+  (cd "$archive_dir" && unpack "$asset_filepath")
 
   # create the destination dir
-  test ! -d "${destination}" && install -d "${destination}"
+  test ! -d "$destination" && install -d "$destination"
 
   # install the binary to the destination dir
   install "${archive_dir}/${binary}" "${destination}/"
@@ -641,16 +641,16 @@ main() (
   done
   shift $((OPTIND - 1))
   set +u
-  tag=$1
+  tag="$1"
 
-  if [ "${install_dir}" = "${DEFAULT_INSTALL_DIR}" ]; then
-    if [ ! -d "${DOCKER_HOME}" ]; then
+  if [ "$install_dir" = "$DEFAULT_INSTALL_DIR" ]; then
+    if [ ! -d "$DOCKER_HOME" ]; then
       log_err "docker is not installed; refusing to install to '${install_dir}'"
       exit 1
     fi
   fi
 
-  if [ -z "${tag}" ]; then
+  if [ -z "$tag" ]; then
     log_debug "checking github for the current release tag"
     tag=""
   else
@@ -658,7 +658,7 @@ main() (
   fi
   set -u
 
-  tag=$(get_release_tag "${OWNER}" "${REPO}" "${tag}")
+  tag=$(get_release_tag "$OWNER" "$REPO" "$tag")
 
   if [ "$?" != "0" ]; then
       log_err "unable to find tag='${tag}'"
@@ -668,21 +668,21 @@ main() (
 
   # run the application
 
-  version=$(tag_to_version "${tag}")
+  version=$(tag_to_version "$tag")
   os=$(uname_os)
   arch=$(uname_arch)
-  format=$(get_format_name "${os}" "${arch}" "tar.gz")
-  binary=$(get_binary_name "${os}" "${arch}" "${BINARY}")
+  format=$(get_format_name "$os" "$arch" "tar.gz")
+  binary=$(get_binary_name "$os" "$arch" "$BINARY")
   download_url="${GITHUB_DOWNLOAD_PREFIX}/${tag}"
 
   # we always use the install.sh script that is associated with the tagged release. Why? the latest install.sh is not
   # guaranteed to be able to install every version of the application. We use the DOWNLOAD_TAG_INSTALL_SCRIPT env var
   # to indicate if we should continue processing with the existing script or to download the script from the given tag.
-  if [ "${DOWNLOAD_TAG_INSTALL_SCRIPT}" = "true" ]; then
+  if [ "$DOWNLOAD_TAG_INSTALL_SCRIPT" = "true" ]; then
       export DOWNLOAD_TAG_INSTALL_SCRIPT=false
       log_info "fetching release script for tag='${tag}'"
       http_copy "${INSTALL_SH_BASE_URL}/${tag}/install.sh" "" | sh -s -- ${PROGRAM_ARGS}
-      exit $?
+      exit "$?"
   fi
 
   log_info "using release tag='${tag}' version='${version}' os='${os}' arch='${arch}'"
@@ -692,7 +692,7 @@ main() (
 
   log_debug "downloading files into ${download_dir}"
 
-  download_and_install_asset "${download_url}" "${download_dir}" "${install_dir}" "${PROJECT_NAME}" "${os}" "${arch}" "${version}" "${format}" "${binary}"
+  download_and_install_asset "$download_url" "$download_dir" "$install_dir" "$PROJECT_NAME" "$os" "$arch" "$version" "$format" "$binary"
 
   # don't continue if we couldn't install the asset
   if [ "$?" != "0" ]; then
@@ -706,7 +706,7 @@ main() (
 # entrypoint
 
 set +u
-if [ -z "${TEST_INSTALL_SH}" ]; then
+if [ -z "$TEST_INSTALL_SH" ]; then
   set -u
   main "$@"
 fi


### PR DESCRIPTION
* escape all variables where the contents aren't obvious
* improve consistency - no curly braces in strings consisting of nothing but one variable

I didn't test it all through and I wasn't sure about line 684, so I left it untouched.

`log_*_priority` seem to be constants - what about a little `readonly` there?