### PR TITLE
ci: trigger release once merged

### DIFF
--- a/.github/workflows/release-branch.yml
+++ b/.github/workflows/release-branch.yml
@@ -47,6 +47,8 @@ jobs:
     if:  startsWith(github.head_ref, 'release/v')
     permissions:
       contents: write
+    outputs:
+      tag: ${{ steps.tagname.outputs.value }}
     runs-on: ubuntu-latest
     needs: test
     steps:
@@ -54,7 +56,6 @@ jobs:
         uses: actions/checkout@v4
         with:
           fetch-depth: 0
-          ref: main
       - name: Tag name
         uses: mad9000/actions-find-and-replace-string@2
         id: tagname
@@ -70,3 +71,12 @@ jobs:
           git merge --ff-only origin/${{ github.head_ref }}
           git tag ${{ steps.tagname.outputs.value }}
           git push https://${GITHUB_ACTOR}:${{ secrets.GITHUB_TOKEN }}@github.com/${{ github.repository }}.git HEAD:main --tags
+
+  create_release:
+    needs:
+      - release
+    uses: ./.github/workflows/release.yml
+    permissions:
+      contents: write
+    with:
+      tag: ${{ needs.release.outputs.tag }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -5,18 +5,30 @@ on:
     tags:
       - 'v*.*.*'
   workflow_dispatch:
+  workflow_call:
+    inputs:
+      tag:
+        required: true
+        type: string
+        description: "The tag to release"
 
 jobs:
   release:
     runs-on: ubuntu-latest
+    permissions:
+      contents: write
+    env:
+      RELEASE_REF: ${{ github.event_name == 'push' && github.ref || inputs.tag }}
     steps:
       - name: Check out code
         uses: actions/checkout@v4
         with:
           fetch-depth: 0
+          ref: ${{ env.RELEASE_REF }}
       - name: Create Release
         uses: softprops/action-gh-release@v1
         with:
           draft: true
+          tag_name: ${{ env.RELEASE_REF }}
           files: |
             dist/docker-scout_*


### PR DESCRIPTION
The merge and the tag will not trigger the release workflow (because it's using the GitHub token).
So call it directly from the workflow, as a shared one.
Keep it shared so we can still trigger it differently if needed.