### PR TITLE
Specify supported OSes in script installation in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,7 +71,7 @@ To install it manually:
 }
 ```
 
-### Script Installation
+### Script Installation (macOS and Linux)
 
 To install, run the following command in your terminal:
 


### PR DESCRIPTION
This PR highlights that the script installation only supports macOS and Linux.