### PR TITLE
Fix examples in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -214,7 +214,7 @@ docker-build:
         docker scout cves "$CI_REGISTRY_IMAGE${tag}" --exit-code --only-severity critical,high    
       else
         # Compare image from branch with latest image from the default branch and fail if new critical or high CVEs are detected
-        docker scout compare "$CI_REGISTRY_IMAGE${tag}" --to "$CI_REGISTRY_IMAGE:latest" --exit-code --only-severity critical,high --ignore-unchanged
+        docker scout compare "$CI_REGISTRY_IMAGE${tag}" --to "$CI_REGISTRY_IMAGE:latest" --exit-on vulnerability,policy --only-severity critical,high --ignore-unchanged
       fi
     
     - docker push "$CI_REGISTRY_IMAGE${tag}"

--- a/README.md
+++ b/README.md
@@ -384,7 +384,7 @@ pipelines:
               docker scout cves "$CI_REGISTRY_IMAGE${tag}" --exit-code --only-severity critical,high    
             else
               # Compare image from branch with latest image from the default branch and fail if new critical or high CVEs are detected            
-              docker scout compare "$CI_REGISTRY_IMAGE${tag}" --to "$CI_REGISTRY_IMAGE:latest" --exit-code --only-severity critical,high --ignore-unchanged
+              docker scout compare "$CI_REGISTRY_IMAGE${tag}" --to "$CI_REGISTRY_IMAGE:latest" --exit-on vulnerability,policy --only-severity critical,high --ignore-unchanged
             fi
           - docker push "$CI_REGISTRY_IMAGE${tag}"
 


### PR DESCRIPTION
The current GitLab CI and Bitbucket examples uses the `--exit-code` flag with the `docker scout compare` command. When I use this flag, a deprecation warning is printed suggesting to use `--exit-on` instead. This is also the only documented option at https://docs.docker.com/reference/cli/docker/scout/compare/#options.